### PR TITLE
gh actions: add check for build sample no error in stdout or stderr

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,10 +28,10 @@ jobs:
         run: bun run lint
 
       - name: Build daemon
-        run : bun run postinstall
+        run : bun run postinstall 
 
       - name: Build sample
-        run: bun i && bun run build
+        run: bun i && bun run build 2>&1 | grep -i "error" && exit 1 || true
         working-directory: ./sample-project
 
       - name: Build docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
         run: bun run lint
 
       - name: Build daemon
-        run : bun run postinstall 
+        run : bun run postinstall
 
       - name: Build sample
         run: bun i && bun run build 2>&1 | grep -i "error" && exit 1 || true


### PR DESCRIPTION
the main branch build which has no error is still ✅, but it will turn red 🔴 with errors if they happen on any branch

<img width="563" alt="image" src="https://github.com/user-attachments/assets/42f55f4e-9bce-4524-ad1d-6bf687214ae4" />

the old failing build with no errors

<img width="867" alt="image" src="https://github.com/user-attachments/assets/fa278e51-6ce0-4306-840b-49b6757ddc48" />


in another PR i had a silently failing build sample step, so this change prevents that from happening:
https://github.com/fable-compiler/vite-plugin-fable/actions/runs/13923112428 